### PR TITLE
Add Fastly service ID configuration to the controller

### DIFF
--- a/controllers/lagoonbuild_controller.go
+++ b/controllers/lagoonbuild_controller.go
@@ -55,6 +55,8 @@ type LagoonBuildReconciler struct {
 	NamespacePrefix       string
 	RandomNamespacePrefix bool
 	ControllerNamespace   string
+	FastlyServiceID       string
+	FastlyWatchStatus     bool
 }
 
 // +kubebuilder:rbac:groups=lagoon.amazee.io,resources=lagoonbuilds,verbs=get;list;watch;create;update;patch;delete
@@ -394,6 +396,14 @@ func (r *LagoonBuildReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 					podEnvs = append(podEnvs, corev1.EnvVar{
 						Name:  "MONITORING_STATUSPAGEID",
 						Value: lagoonBuild.Spec.Project.Monitoring.StatuspageID,
+					})
+				}
+				// if the fastly watch status is set on the controller, inject the fastly service ID into the build pod to be consumed
+				// by the build-depoy-dind image
+				if r.FastlyWatchStatus {
+					podEnvs = append(podEnvs, corev1.EnvVar{
+						Name:  "LAGOON_FASTLY_NOCACHE_SERVICE_ID",
+						Value: r.FastlyServiceID,
 					})
 				}
 				// Use the build image in the controller definition

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	lagoonv1alpha1 "github.com/amazeeio/lagoon-kbd/api/v1alpha1"
@@ -74,6 +75,8 @@ func main() {
 	var randomPrefix bool
 	var isOpenshift bool
 	var controllerNamespace string
+	var fastlyServiceID string
+	var fastlyWatchStatus bool
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080",
 		"The address the metric endpoint binds to.")
@@ -119,6 +122,10 @@ func main() {
 		"The host address for the Lagoon SSH service.")
 	flag.StringVar(&lagoonSSHPort, "lagoon-ssh-port", "2020",
 		"The port for the Lagoon SSH service.")
+	flag.StringVar(&fastlyServiceID, "fastly-service-id", "",
+		"The service ID that should be added to any ingresses to use the lagoon no-cache service for this cluster.")
+	flag.BoolVar(&fastlyWatchStatus, "fastly-watch-status", false,
+		"Flag to determine if the fastly.amazee.io/watch status should be added to any ingresses to use the lagoon no-cache service for this cluster.")
 	flag.Parse()
 
 	// get overrides from environment variables
@@ -149,6 +156,12 @@ func main() {
 	lagoonAPIHost = getEnv("TASK_API_HOST", lagoonAPIHost)
 	lagoonSSHHost = getEnv("TASK_SSH_HOST", lagoonSSHHost)
 	lagoonSSHPort = getEnv("TASK_SSH_PORT", lagoonSSHPort)
+
+	// Fastly configuration options
+	// the service id should be that for the cluster which will be used as the default no-cache passthrough
+	fastlyServiceID = getEnv("FASTLY_SERVICE_ID", fastlyServiceID)
+	// this is used to control setting the service id into build pods
+	fastlyWatchStatus = getEnvBool("FASTLY_WATCH_STATUS", fastlyWatchStatus)
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
 		o.Development = true
@@ -317,6 +330,8 @@ func main() {
 		NamespacePrefix:       namespacePrefix,
 		RandomNamespacePrefix: randomPrefix,
 		ControllerNamespace:   controllerNamespace,
+		FastlyServiceID:       fastlyServiceID,
+		FastlyWatchStatus:     fastlyWatchStatus,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonBuild")
 		os.Exit(1)
@@ -358,6 +373,16 @@ func main() {
 func getEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
+	}
+	return fallback
+}
+
+// accepts fallback values 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False
+// anything else is false.
+func getEnvBool(key string, fallback bool) bool {
+	if value, ok := os.LookupEnv(key); ok {
+		rVal, _ := strconv.ParseBool(value)
+		return rVal
 	}
 	return fallback
 }


### PR DESCRIPTION
This adds support for defining the Fastly no-cache service ID for the cluster the controller is running in.

It will inject the variable `LAGOON_FASTLY_NOCACHE_SERVICE_ID` into all Lagoon builds that are started by this controller if the `fastly-watch-status` flag is set to true.