### PR TITLE
feat: add SHORT_ROUTER_URL to the build environment

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base32"
 	"fmt"
 	"math/rand"
 	"regexp"
@@ -91,4 +93,14 @@ func hashString(s string) string {
 	h.Write([]byte(s))
 	bs := h.Sum(nil)
 	return fmt.Sprintf("%x", bs)
+}
+
+var lowerAlNum = regexp.MustCompile("[^a-z0-9]+")
+
+// shortName returns a deterministic random short name of 8 lowercase
+// alphabetic and numeric characters. The short name is based
+// on hashing and encoding the given name.
+func shortName(name string) string {
+	hash := sha256.Sum256([]byte(name))
+	return lowerAlNum.ReplaceAllString(strings.ToLower(base32.StdEncoding.EncodeToString(hash[:])), "")[:8]
 }

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -1,0 +1,23 @@
+package controllers
+
+import "testing"
+
+func TestShortName(t *testing.T) {
+	var testCases = map[string]struct {
+		input  string
+		expect string
+	}{
+		"small string 0": {input: "foo", expect: "fqtli23i"},
+		"small string 1": {input: "bar", expect: "7tpcwlw3"},
+		"small string 2": {input: "bard", expect: "sbmpphej"},
+		"large string 0": {input: "very-very-very-long-string-here-much-more-than-sixty-three-chars", expect: "iil2toyi"},
+		"large string 1": {input: "very-very-very-long-string-here-much-more-than-sixty-three-characters", expect: "54flwlga"},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(tt *testing.T) {
+			if output := shortName(tc.input); output != tc.expect {
+				tt.Fatalf("expected: %v, got: %v", tc.expect, output)
+			}
+		})
+	}
+}

--- a/controllers/lagoonbuild_controller.go
+++ b/controllers/lagoonbuild_controller.go
@@ -324,6 +324,22 @@ func (r *LagoonBuildReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 							),
 						),
 					})
+					podEnvs = append(podEnvs, corev1.EnvVar{
+						Name: "SHORT_ROUTER_URL",
+						Value: strings.ToLower(
+							strings.Replace(
+								strings.Replace(
+									lagoonBuild.Spec.Project.RouterPattern,
+									"${environment}",
+									shortName(lagoonBuild.Spec.Project.Environment),
+									-1,
+								),
+								"${project}",
+								shortName(lagoonBuild.Spec.Project.Name),
+								-1,
+							),
+						),
+					})
 				}
 				if lagoonBuild.Spec.Build.CI != "" {
 					podEnvs = append(podEnvs, corev1.EnvVar{


### PR DESCRIPTION
The domain name of this URL is (almost) guaranteed to be less than 63 chars in length, so it can be used as a CN in certificate requests.

The use of base32 is an attempt to increase the entropy of the 8 character string over simple hex encoding, in order to reduce the likelihood of collisions. Not sure how necessary it is, really.

This is part of a fix for https://github.com/amazeeio/lagoon/issues/2310