### PR TITLE
support newer "lagoon.sh/build" taint

### DIFF
--- a/controllers/lagoonbuild_controller.go
+++ b/controllers/lagoonbuild_controller.go
@@ -517,6 +517,16 @@ func (r *LagoonBuildReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 								Effect:   "PreferNoSchedule",
 								Operator: "Exists",
 							},
+							{
+								Key:      "lagoon.sh/build",
+								Effect:   "NoSchedule",
+								Operator: "Exists",
+							},
+							{
+								Key:      "lagoon.sh/build",
+								Effect:   "PreferNoSchedule",
+								Operator: "Exists",
+							},
 						},
 						Containers: []corev1.Container{
 							{


### PR DESCRIPTION
currently we use the `lagoon/build` taint, but we should actually use the correct way with a DNS key: `lagoon.sh/build`