### PR TITLE
Implement pod cleanup cronjobs

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -23,3 +23,5 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
+        - "--build-pod-cleanup-cron=*/1 * * * *"
+        - "--task-pod-cleanup-cron=*/1 * * * *"

--- a/handlers/pod_cleanup.go
+++ b/handlers/pod_cleanup.go
@@ -67,16 +67,18 @@ func (h *Cleanup) BuildPodCleanup() {
 		}
 		// sort the build pods by creation timestamp
 		sort.Slice(buildPods.Items, func(i, j int) bool {
-			return buildPods.Items[i].ObjectMeta.CreationTimestamp.Before(&buildPods.Items[j].ObjectMeta.CreationTimestamp)
+			return buildPods.Items[i].ObjectMeta.CreationTimestamp.After(buildPods.Items[j].ObjectMeta.CreationTimestamp.Time)
 		})
 		if len(buildPods.Items) > h.NumBuildPodsToKeep {
 			for idx, pod := range buildPods.Items {
-				if idx >= h.NumBuildPodsToKeep &&
-					pod.Status.Phase == corev1.PodFailed ||
-					pod.Status.Phase == corev1.PodSucceeded {
-					if err := h.Client.Delete(context.Background(), &pod); err != nil {
-						opLog.Error(err, fmt.Sprintf("Unable to update status condition"))
-						break
+				if idx >= h.NumBuildPodsToKeep {
+					if pod.Status.Phase == corev1.PodFailed ||
+						pod.Status.Phase == corev1.PodSucceeded {
+						opLog.Info(fmt.Sprintf("Cleaning up pod %s", pod.ObjectMeta.Name))
+						if err := h.Client.Delete(context.Background(), &pod); err != nil {
+							opLog.Error(err, fmt.Sprintf("Unable to update status condition"))
+							break
+						}
 					}
 				}
 			}
@@ -115,16 +117,18 @@ func (h *Cleanup) TaskPodCleanup() {
 		}
 		// sort the build pods by creation timestamp
 		sort.Slice(taskPods.Items, func(i, j int) bool {
-			return taskPods.Items[i].ObjectMeta.CreationTimestamp.Before(&taskPods.Items[j].ObjectMeta.CreationTimestamp)
+			return taskPods.Items[i].ObjectMeta.CreationTimestamp.After(taskPods.Items[j].ObjectMeta.CreationTimestamp.Time)
 		})
 		if len(taskPods.Items) > h.NumTaskPodsToKeep {
 			for idx, pod := range taskPods.Items {
-				if idx >= h.NumTaskPodsToKeep &&
-					pod.Status.Phase == corev1.PodFailed ||
-					pod.Status.Phase == corev1.PodSucceeded {
-					if err := h.Client.Delete(context.Background(), &pod); err != nil {
-						opLog.Error(err, fmt.Sprintf("Unable to delete pod"))
-						break
+				if idx >= h.NumTaskPodsToKeep {
+					if pod.Status.Phase == corev1.PodFailed ||
+						pod.Status.Phase == corev1.PodSucceeded {
+						opLog.Info(fmt.Sprintf("Cleaning up pod %s", pod.ObjectMeta.Name))
+						if err := h.Client.Delete(context.Background(), &pod); err != nil {
+							opLog.Error(err, fmt.Sprintf("Unable to delete pod"))
+							break
+						}
 					}
 				}
 			}

--- a/handlers/pod_cleanup.go
+++ b/handlers/pod_cleanup.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type cleanup interface {
+	BuildPodCleanup()
+	TaskPodCleanup()
+}
+
+// Cleanup is used for cleaning up old pods or resources.
+type Cleanup struct {
+	Client              client.Client
+	NumTaskPodsToKeep   int
+	NumBuildPodsToKeep  int
+	ControllerNamespace string
+	EnableDebug         bool
+}
+
+// NewCleanup returns a cleanup with controller-runtime client.
+func NewCleanup(client client.Client, numTaskPodsToKeep int, numBuildPodsToKeep int, controllerNamespace string, enableDebug bool) *Cleanup {
+	return &Cleanup{
+		Client:              client,
+		NumTaskPodsToKeep:   numTaskPodsToKeep,
+		NumBuildPodsToKeep:  numBuildPodsToKeep,
+		ControllerNamespace: controllerNamespace,
+		EnableDebug:         enableDebug,
+	}
+}
+
+// BuildPodCleanup will clean up any build pods that are hanging around.
+func (h *Cleanup) BuildPodCleanup() {
+	opLog := ctrl.Log.WithName("handlers").WithName("BuildPodCleanup")
+	namespaces := &corev1.NamespaceList{}
+	labelRequirements, _ := labels.NewRequirement("lagoon.sh/environmentType", selection.Exists, nil)
+	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.MatchingLabelsSelector{
+			Selector: labels.NewSelector().Add(*labelRequirements),
+		},
+	})
+	if err := h.Client.List(context.Background(), namespaces, listOption); err != nil {
+		opLog.Error(err, fmt.Sprintf("Unable to list namespaces created by Lagoon, there may be none or something went wrong"))
+		return
+	}
+	for _, ns := range namespaces.Items {
+		opLog.Info(fmt.Sprintf("Checking Lagoon build pods in namespace %s", ns.ObjectMeta.Name))
+		buildPods := &corev1.PodList{}
+		listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+			client.InNamespace(ns.ObjectMeta.Name),
+			client.MatchingLabels(map[string]string{
+				"lagoon.sh/jobType":    "build",
+				"lagoon.sh/controller": h.ControllerNamespace, // created by this controller
+			}),
+		})
+		if err := h.Client.List(context.Background(), buildPods, listOption); err != nil {
+			opLog.Error(err, fmt.Sprintf("Unable to list Lagoon build pods, there may be none or something went wrong"))
+			return
+		}
+		// sort the build pods by creation timestamp
+		sort.Slice(buildPods.Items, func(i, j int) bool {
+			return buildPods.Items[i].ObjectMeta.CreationTimestamp.Before(&buildPods.Items[j].ObjectMeta.CreationTimestamp)
+		})
+		if len(buildPods.Items) > h.NumBuildPodsToKeep {
+			for idx, pod := range buildPods.Items {
+				if idx >= h.NumBuildPodsToKeep &&
+					pod.Status.Phase == corev1.PodFailed ||
+					pod.Status.Phase == corev1.PodSucceeded {
+					if err := h.Client.Delete(context.Background(), &pod); err != nil {
+						opLog.Error(err, fmt.Sprintf("Unable to update status condition"))
+						break
+					}
+				}
+			}
+		}
+	}
+	return
+}
+
+// TaskPodCleanup will clean up any task pods that are hanging around.
+func (h *Cleanup) TaskPodCleanup() {
+	opLog := ctrl.Log.WithName("handlers").WithName("TaskPodCleanup")
+	namespaces := &corev1.NamespaceList{}
+	labelRequirements, _ := labels.NewRequirement("lagoon.sh/environmentType", selection.Exists, nil)
+	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.MatchingLabelsSelector{
+			Selector: labels.NewSelector().Add(*labelRequirements),
+		},
+	})
+	if err := h.Client.List(context.Background(), namespaces, listOption); err != nil {
+		opLog.Error(err, fmt.Sprintf("Unable to list namespaces created by Lagoon, there may be none or something went wrong"))
+		return
+	}
+	for _, ns := range namespaces.Items {
+		opLog.Info(fmt.Sprintf("Checking Lagoon task pods in namespace %s", ns.ObjectMeta.Name))
+		taskPods := &corev1.PodList{}
+		listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+			client.InNamespace(ns.ObjectMeta.Name),
+			client.MatchingLabels(map[string]string{
+				"lagoon.sh/jobType":    "task",
+				"lagoon.sh/controller": h.ControllerNamespace, // created by this controller
+			}),
+		})
+		if err := h.Client.List(context.Background(), taskPods, listOption); err != nil {
+			opLog.Error(err, fmt.Sprintf("Unable to list Lagoon task pods, there may be none or something went wrong"))
+			return
+		}
+		// sort the build pods by creation timestamp
+		sort.Slice(taskPods.Items, func(i, j int) bool {
+			return taskPods.Items[i].ObjectMeta.CreationTimestamp.Before(&taskPods.Items[j].ObjectMeta.CreationTimestamp)
+		})
+		if len(taskPods.Items) > h.NumTaskPodsToKeep {
+			for idx, pod := range taskPods.Items {
+				if idx >= h.NumTaskPodsToKeep &&
+					pod.Status.Phase == corev1.PodFailed ||
+					pod.Status.Phase == corev1.PodSucceeded {
+					if err := h.Client.Delete(context.Background(), &pod); err != nil {
+						opLog.Error(err, fmt.Sprintf("Unable to delete pod"))
+						break
+					}
+				}
+			}
+		}
+	}
+	return
+}

--- a/handlers/pod_cleanup.go
+++ b/handlers/pod_cleanup.go
@@ -20,18 +20,18 @@ type cleanup interface {
 // Cleanup is used for cleaning up old pods or resources.
 type Cleanup struct {
 	Client              client.Client
-	NumTaskPodsToKeep   int
-	NumBuildPodsToKeep  int
+	TaskPodsToKeep      int
+	BuildPodsToKeep     int
 	ControllerNamespace string
 	EnableDebug         bool
 }
 
 // NewCleanup returns a cleanup with controller-runtime client.
-func NewCleanup(client client.Client, numTaskPodsToKeep int, numBuildPodsToKeep int, controllerNamespace string, enableDebug bool) *Cleanup {
+func NewCleanup(client client.Client, taskPodsToKeep int, buildPodsToKeep int, controllerNamespace string, enableDebug bool) *Cleanup {
 	return &Cleanup{
 		Client:              client,
-		NumTaskPodsToKeep:   numTaskPodsToKeep,
-		NumBuildPodsToKeep:  numBuildPodsToKeep,
+		TaskPodsToKeep:      taskPodsToKeep,
+		BuildPodsToKeep:     buildPodsToKeep,
 		ControllerNamespace: controllerNamespace,
 		EnableDebug:         enableDebug,
 	}
@@ -69,9 +69,9 @@ func (h *Cleanup) BuildPodCleanup() {
 		sort.Slice(buildPods.Items, func(i, j int) bool {
 			return buildPods.Items[i].ObjectMeta.CreationTimestamp.After(buildPods.Items[j].ObjectMeta.CreationTimestamp.Time)
 		})
-		if len(buildPods.Items) > h.NumBuildPodsToKeep {
+		if len(buildPods.Items) > h.BuildPodsToKeep {
 			for idx, pod := range buildPods.Items {
-				if idx >= h.NumBuildPodsToKeep {
+				if idx >= h.BuildPodsToKeep {
 					if pod.Status.Phase == corev1.PodFailed ||
 						pod.Status.Phase == corev1.PodSucceeded {
 						opLog.Info(fmt.Sprintf("Cleaning up pod %s", pod.ObjectMeta.Name))
@@ -119,9 +119,9 @@ func (h *Cleanup) TaskPodCleanup() {
 		sort.Slice(taskPods.Items, func(i, j int) bool {
 			return taskPods.Items[i].ObjectMeta.CreationTimestamp.After(taskPods.Items[j].ObjectMeta.CreationTimestamp.Time)
 		})
-		if len(taskPods.Items) > h.NumTaskPodsToKeep {
+		if len(taskPods.Items) > h.TaskPodsToKeep {
 			for idx, pod := range taskPods.Items {
-				if idx >= h.NumTaskPodsToKeep {
+				if idx >= h.TaskPodsToKeep {
 					if pod.Status.Phase == corev1.PodFailed ||
 						pod.Status.Phase == corev1.PodSucceeded {
 						opLog.Info(fmt.Sprintf("Cleaning up pod %s", pod.ObjectMeta.Name))

--- a/main.go
+++ b/main.go
@@ -373,6 +373,7 @@ func main() {
 	)
 	// if the build pod cleanup is enabled, add the cronjob for it
 	if enableBuildPodCleanUp {
+		setupLog.Info("starting build pod cleanup handler")
 		// use cron to run a build pod cleanup task
 		// this will check any Lagoon build pods and attempt to delete them
 		c := cron.New()
@@ -383,6 +384,7 @@ func main() {
 	}
 	// if the task pod cleanup is enabled, add the cronjob for it
 	if enableTaskPodCleanUp {
+		setupLog.Info("starting task pod cleanup handler")
 		// use cron to run a task pod cleanup task
 		// this will check any Lagoon task pods and attempt to delete them
 		c := cron.New()

--- a/test-resources/example-project2.yaml
+++ b/test-resources/example-project2.yaml
@@ -1,0 +1,31 @@
+kind: LagoonBuild
+apiVersion: lagoon.amazee.io/v1alpha1
+metadata:
+    name: lagoon-build-9m5zypx
+spec:
+    build:
+        ci: 'true' #to make sure that readwritemany is changed to readwriteonce
+        image: amazeeio/kubectl-build-deploy-dind:latest
+        type: branch
+    gitReference: origin/install
+    project:
+        name: drupal-example
+        environment: install
+        uiLink: https://dashboard.amazeeio.cloud/projects/project/project-environment/deployments/lagoon-build-7m5zypx
+        routerPattern: 'install-drupal-example'
+        environmentType: production
+        productionEnvironment: install
+        standbyEnvironment: master
+        gitUrl: https://github.com/amazeeio/drupal-example-simple.git
+        deployTarget: kind
+        projectSecret: 4d6e7dd0f013a75d62a0680139fa82d350c2a1285f43f867535bad1143f228b1
+        key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlDWFFJQkFBS0JnUUNjc1g2RG5KNXpNb0RqQ2R6a1JFOEg2TEh2TDQzaUhsekJLTWo4T1VNV05ZZG5YekdqCkR5Mkp1anQ3ZDNlMTVLeC8zOFo5UzJLdHNnVFVtWi9lUlRQSTdabE1idHRJK250UmtyblZLblBWNzhEeEFKNW8KTGZtQndmdWE2MnlVYnl0cnpYQ2pwVVJrQUlBMEZiR2VqS2Rvd3cxcnZGMzJoZFUzQ3ZIcG5rKzE2d0lEQVFBQgpBb0dCQUkrV0dyL1NDbVMzdCtIVkRPVGtMNk9vdVR6Y1QrRVFQNkVGbGIrRFhaV0JjZFhwSnB3c2NXZFBEK2poCkhnTEJUTTFWS3hkdnVEcEE4aW83cUlMTzJWYm1MeGpNWGk4TUdwY212dXJFNVJydTZTMXJzRDl2R0c5TGxoR3UKK0pUSmViMVdaZFduWFZ2am5LbExrWEV1eUthbXR2Z253Um5xNld5V05OazJ6SktoQWtFQThFenpxYnowcFVuTApLc241K2k0NUdoRGVpRTQvajRtamo1b1FHVzJxbUZWT2pHaHR1UGpaM2lwTis0RGlTRkFyMkl0b2VlK085d1pyCkRINHBkdU5YOFFKQkFLYnVOQ3dXK29sYXA4R2pUSk1TQjV1MW8wMVRHWFdFOGhVZG1leFBBdjl0cTBBT0gzUUQKUTIrM0RsaVY0ektoTlMra2xaSkVjNndzS0YyQmJIby81NXNDUVFETlBJd24vdERja3loSkJYVFJyc1RxZEZuOApCUWpZYVhBZTZEQ3o1eXg3S3ZFSmp1K1h1a01xTXV1ajBUSnpITFkySHVzK3FkSnJQVG9VMDNSS3JHV2hBa0JFCnB3aXI3Vk5pYy9jMFN2MnVLcWNZWWM1a2ViMnB1R0I3VUs1Q0lvaWdGakZzNmFJRDYyZXJwVVJ3S0V6RlFNbUgKNjQ5Y0ZXemhMVlA0aU1iZFREVHJBa0FFMTZXU1A3WXBWOHV1eFVGMGV0L3lFR3dURVpVU2R1OEppSTBHN0tqagpqcVR6RjQ3YkJZc0pIYTRYcWpVb2E3TXgwcS9FSUtRWkJ2NGFvQm42bGFOQwotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQ==
+        monitoring:
+            contact: '1234'
+            statuspageID: '1234'
+        variables:
+            project: W10=
+            environment: W10=
+        registry: 172.17.0.1:5000
+    branch:
+        name: install


### PR DESCRIPTION
This adds 2 cronjobs to the manager

* Build pod cleanup
  * Runs every hour on the hour
  * Retains 1 pod per namespace that isn't running/pending
* Task pod cleanup
  * Runs every hour on the half hour
  * Retains 1 pod per namespace that isn't running/pending

These are all configurable with flags
```
#builds defaults
--enable-build-pod-cleanup=true
--build-pod-cleanup-cron="0 * * * *"
--num-build-pods-to-keep=1
#tasks defaults
--enable-task-pod-cleanup=true 
--task-pod-cleanup-cron="30 * * * *"
--num-task-pods-to-keep=1
```

closes #39 